### PR TITLE
feat: track passwordChangedAt on password writes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,5 +1,5 @@
 {
-  "hash": "32fdca154a0dc1d7a0200aa8059b4927d0a7cf297acc843beb792e348b72a6da",
+  "hash": "beb77cb0b37924ed4121b87dbd01aea157eb2cde455025934bcea22b64dba1a6",
   "openapi": "3.0.0",
   "paths": {
     "/hello": {
@@ -6010,6 +6010,11 @@
             "description": "密码",
             "writeOnly": true
           },
+          "passwordChangedAt": {
+            "type": "string",
+            "description": "上次修改密码时间（与密码哈希一并维护，用于口令轮换等策略）",
+            "format": "date-time"
+          },
           "hasPassword": {
             "type": "boolean",
             "description": "是否有密码",
@@ -7556,6 +7561,11 @@
             "description": "密码",
             "writeOnly": true
           },
+          "passwordChangedAt": {
+            "type": "string",
+            "description": "上次修改密码时间（与密码哈希一并维护，用于口令轮换等策略）",
+            "format": "date-time"
+          },
           "hasPassword": {
             "type": "boolean",
             "description": "是否有密码",
@@ -7695,6 +7705,11 @@
       "UpdateUserDto": {
         "type": "object",
         "properties": {
+          "passwordChangedAt": {
+            "type": "string",
+            "description": "上次修改密码时间（与密码哈希一并维护，用于口令轮换等策略）",
+            "format": "date-time"
+          },
           "hasPassword": {
             "type": "boolean",
             "description": "是否有密码",

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -159,6 +159,16 @@ export class UserDoc {
   password?: string;
 
   /**
+   * 上次修改密码时间（与密码哈希一并维护，用于口令轮换等策略）
+   */
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  @ApiProperty({ type: String, format: 'date-time', required: false })
+  @Prop()
+  passwordChangedAt?: Date;
+
+  /**
    * 手机号
    */
   @IsOptional()

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -59,10 +59,13 @@ describe('UserService', () => {
   describe('createUser', () => {
     it('should create a user', async () => {
       const userDoc = mockUser();
+      const before = Date.now();
       const user = await userService.create(userDoc);
       expect(user).toBeDefined();
       expect(typeof user.id).toBe('string');
       expect(userService.checkPassword(user.password, userDoc.password)).toBeTruthy();
+      expect(user.passwordChangedAt).toBeInstanceOf(Date);
+      expect(user.passwordChangedAt.getTime()).toBeGreaterThanOrEqual(before);
     });
 
     it('should keep an explicit id when provided', async () => {
@@ -153,11 +156,25 @@ describe('UserService', () => {
     });
   });
 
+  describe('updatePassword', () => {
+    it('should set passwordChangedAt when password is updated', async () => {
+      const user = await userService.create(mockUser());
+      const before = Date.now();
+      const updated = await userService.updatePassword(user.id, 'new-secret-1');
+      expect(userService.checkPassword(updated.password, 'new-secret-1')).toBe(true);
+      expect(updated.passwordChangedAt).toBeInstanceOf(Date);
+      expect(updated.passwordChangedAt.getTime()).toBeGreaterThanOrEqual(before);
+    });
+  });
+
   describe('upsertUser', () => {
     it('should upsert a user', async () => {
       const userDoc = mockUser();
+      const before = Date.now();
       const user = await userService.upsertByPhone('18888888888', userDoc);
       expect(user.email).toBe(userDoc.email);
+      expect(user.passwordChangedAt).toBeInstanceOf(Date);
+      expect(user.passwordChangedAt.getTime()).toBeGreaterThanOrEqual(before);
     });
 
     it('should upsert a user by id', async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -36,6 +36,7 @@ function hashPwd(dto: CreateUserDto) {
   const res = { ...dto };
   if (dto.password) {
     res.password = createHash(dto.password);
+    res.passwordChangedAt = new Date();
   }
   return res;
 }
@@ -193,7 +194,11 @@ export class UserService {
 
   updatePassword(id: string, password: string): Promise<UserDocument> {
     return this.userModel
-      .findByIdAndUpdate(id, { password: createHash(password) }, { new: true })
+      .findByIdAndUpdate(
+        id,
+        { password: createHash(password), passwordChangedAt: new Date() },
+        { new: true }
+      )
       .exec();
   }
 


### PR DESCRIPTION
## Summary
- add `passwordChangedAt` to the user entity and generated OpenAPI schema
- update create, upsert, and password update flows to persist the timestamp whenever a password hash is written
- add service tests covering create, updatePassword, and upsert behavior

## Testing
- `pnpm test src/user/user.service.spec.ts --runInBand`
- `pnpm test`