### PR TITLE
fix: invalidate user cache after password update

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -298,6 +298,8 @@ export class UserController {
    */
   @ApiOperation({ operationId: 'updatePassword' })
   @HttpCode(HttpStatus.NO_CONTENT)
+  @UseInterceptors(UnsetCacheInterceptor)
+  @CacheKey('/users/:userId')
   @Post(':userId/@updatePassword')
   async updatePassword(
     @Param('userId') userId: string,


### PR DESCRIPTION
## Summary
- invalidate the cached user detail entry when `POST /users/:userId/@updatePassword` succeeds
- use `/users/:userId` as the cache key so 204 responses can still delete the concrete cache entry
- keep password rotation reads aligned with the latest `passwordChangedAt`

## Testing
- pnpm exec eslint src/user/user.controller.ts
- pnpm build
- pnpm test
- verified locally that `GET /users/:id` returns the new `passwordChangedAt` immediately after `@updatePassword`
