### PR TITLE
fix: sign token with acl & login user

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,5 +1,5 @@
 {
-  "hash": "beb77cb0b37924ed4121b87dbd01aea157eb2cde455025934bcea22b64dba1a6",
+  "hash": "9c9667fc9c2b41847a5dca17a8678df533cbcbdc717cf5fd34dddf4ed5e556b8",
   "openapi": "3.0.0",
   "paths": {
     "/hello": {
@@ -6305,6 +6305,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "acl": {
+            "type": "object",
+            "description": "访问控制列表"
           }
         },
         "required": [

--- a/openapi.json
+++ b/openapi.json
@@ -1,5 +1,5 @@
 {
-  "hash": "9c9667fc9c2b41847a5dca17a8678df533cbcbdc717cf5fd34dddf4ed5e556b8",
+  "hash": "3e45e84c633b2b3f2d51343bd71a6f525010b2ef4b9717314525a4d36568452e",
   "openapi": "3.0.0",
   "paths": {
     "/hello": {
@@ -5816,6 +5816,17 @@
             "type": "boolean",
             "description": "不存在用户时是否自动注册"
           },
+          "active": {
+            "type": "boolean",
+            "description": "自动注册时是否启用（不传则使用服务端默认）"
+          },
+          "roles": {
+            "description": "自动注册时的角色（不传则使用服务端默认）",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "ns": {
             "type": "string",
             "description": "命名空间"
@@ -5869,6 +5880,17 @@
             "type": "boolean",
             "description": "不存在用户时是否自动注册"
           },
+          "active": {
+            "type": "boolean",
+            "description": "自动注册时是否启用（不传则使用服务端默认）"
+          },
+          "roles": {
+            "description": "自动注册时的角色（不传则使用服务端默认）",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "ns": {
             "type": "string",
             "description": "命名空间"
@@ -5913,6 +5935,17 @@
           "autoRegister": {
             "type": "boolean",
             "description": "不存在用户时是否自动注册"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "自动注册时是否启用（不传则使用服务端默认）"
+          },
+          "roles": {
+            "description": "自动注册时的角色（不传则使用服务端默认）",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "ns": {
             "type": "string",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -257,6 +257,8 @@ export class AuthController {
         registerIp: dto.registerIp,
         registerRegion: dto.registerRegion,
         type: dto.type,
+        ...(dto.active !== undefined && { active: dto.active }),
+        ...(dto.roles !== undefined && { roles: dto.roles }),
       });
     }
 
@@ -300,6 +302,8 @@ export class AuthController {
         registerIp: dto.registerIp,
         registerRegion: dto.registerRegion,
         type: dto.type,
+        ...(dto.active !== undefined && { active: dto.active }),
+        ...(dto.roles !== undefined && { roles: dto.roles }),
       });
     }
 
@@ -344,6 +348,8 @@ export class AuthController {
         registerIp: dto.registerIp,
         registerRegion: dto.registerRegion,
         type: dto.type,
+        ...(dto.active !== undefined && { active: dto.active }),
+        ...(dto.roles !== undefined && { roles: dto.roles }),
       });
     }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -493,10 +493,12 @@ export class AuthController {
     }
 
     const jwtpayload: JwtPayload = {
+      roles: user.roles,
       ns: user.ns,
       type: user.type,
       groups: user.groups,
       permissions: dto.permissions,
+      acl: dto.acl,
     };
 
     const token = this.jwtService.sign(jwtpayload, {

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -48,6 +48,20 @@ export class LoginByPhoneDto {
   autoRegister?: boolean;
 
   /**
+   * 自动注册时是否启用（不传则使用服务端默认）
+   */
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+
+  /**
+   * 自动注册时的角色（不传则使用服务端默认）
+   */
+  @IsOptional()
+  @IsString({ each: true })
+  roles?: string[];
+
+  /**
    * 命名空间
    */
   @IsOptional()
@@ -104,6 +118,20 @@ export class LoginByPhoneQuickAuthDto {
   @IsOptional()
   @IsBoolean()
   autoRegister?: boolean;
+
+  /**
+   * 自动注册时是否启用（不传则使用服务端默认）
+   */
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+
+  /**
+   * 自动注册时的角色（不传则使用服务端默认）
+   */
+  @IsOptional()
+  @IsString({ each: true })
+  roles?: string[];
 
   /**
    * 命名空间
@@ -177,6 +205,20 @@ export class LoginByEmailDto {
   @IsOptional()
   @IsBoolean()
   autoRegister?: boolean;
+
+  /**
+   * 自动注册时是否启用（不传则使用服务端默认）
+   */
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+
+  /**
+   * 自动注册时的角色（不传则使用服务端默认）
+   */
+  @IsOptional()
+  @IsString({ each: true })
+  roles?: string[];
 
   /**
    * 命名空间

--- a/src/auth/dto/sign-token.dto.ts
+++ b/src/auth/dto/sign-token.dto.ts
@@ -1,4 +1,6 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+
+import { Acl } from 'src/auth/entities/jwt.entity';
 
 export class SignTokenDto {
   /**
@@ -35,4 +37,11 @@ export class SignTokenDto {
   @IsOptional()
   @IsString({ each: true })
   permissions?: string[];
+
+  /**
+   * 访问控制列表
+   */
+  @IsOptional()
+  @IsObject()
+  acl?: Acl;
 }


### PR DESCRIPTION
这个 PR 完成了部分接口的调整

- 签发 token 接口支持设置 acl
- 支持自动注册的登录接口，同样支持设置新增用户的部分属性

### 发布建议

- 上线时需要设置的环境变量或参数
- 如果需要修改更新线上数据的还需要提供迁移脚本

### 相关资料

- https://guild.adventurer.tech/projects/7/tickets/257
