### PR TITLE
fix: allow display name in email from field

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,5 +1,5 @@
 {
-  "hash": "2284d91996d1b44f5934a851eca1543a146010d858b454e067536ecad05b5515",
+  "hash": "784097a775e52168883b76a7f9a709a61104d472edba7731896d3f0369068f3f",
   "openapi": "3.0.0",
   "paths": {
     "/hello": {
@@ -1013,7 +1013,7 @@
             "name": "from",
             "required": false,
             "in": "query",
-            "description": "发件者",
+            "description": "发件者，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `\"robot\" <robot@mail.36node.com>`",
             "schema": {
               "type": "string"
             }
@@ -1146,7 +1146,7 @@
             "name": "from",
             "required": false,
             "in": "query",
-            "description": "发件者",
+            "description": "发件者，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `\"robot\" <robot@mail.36node.com>`",
             "schema": {
               "type": "string"
             }
@@ -6672,7 +6672,8 @@
         "type": "object",
         "properties": {
           "from": {
-            "type": "string"
+            "type": "string",
+            "description": "发件人地址，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `\"robot\" <robot@mail.36node.com>`"
           },
           "to": {
             "type": "string"
@@ -6715,7 +6716,7 @@
           },
           "from": {
             "type": "string",
-            "description": "发件者"
+            "description": "发件者，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `\"robot\" <robot@mail.36node.com>`"
           },
           "to": {
             "type": "string",
@@ -6756,7 +6757,7 @@
           },
           "from": {
             "type": "string",
-            "description": "发件者"
+            "description": "发件者，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `\"robot\" <robot@mail.36node.com>`"
           },
           "to": {
             "type": "string",
@@ -6820,7 +6821,7 @@
           },
           "from": {
             "type": "string",
-            "description": "发件者"
+            "description": "发件者，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `\"robot\" <robot@mail.36node.com>`"
           },
           "to": {
             "type": "string",
@@ -8610,7 +8611,7 @@
           },
           "from": {
             "type": "string",
-            "description": "发件者"
+            "description": "发件者，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `\"robot\" <robot@mail.36node.com>`"
           },
           "to": {
             "type": "string",

--- a/src/email/dto/send-email.dto.ts
+++ b/src/email/dto/send-email.dto.ts
@@ -1,8 +1,11 @@
 import { IsBoolean, IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class SendEmailDto {
+  /**
+   * 发件人地址，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `"robot" <robot@mail.36node.com>`
+   */
   @IsNotEmpty()
-  @IsEmail()
+  @IsEmail({ allow_display_name: true })
   from: string;
 
   @IsNotEmpty()

--- a/src/email/entities/email-record.entity.ts
+++ b/src/email/entities/email-record.entity.ts
@@ -23,10 +23,10 @@ export enum EmailStatus {
 @SortFields(['sentAt'])
 export class EmailRecordDoc {
   /**
-   * 发件者
+   * 发件者，支持纯邮箱或带显示名格式，例如 `robot@mail.36node.com` 或 `"robot" <robot@mail.36node.com>`
    */
   @IsNotEmpty()
-  @IsEmail()
+  @IsEmail({ allow_display_name: true })
   @Prop()
   from: string;
 


### PR DESCRIPTION
## Summary
- `from` 字段校验放宽为 `@IsEmail({ allow_display_name: true })`，支持带发件人显示名格式（如 `"robot" <robot@mail.36node.com>`）
- 同步调整 `SendEmailDto` 与 `EmailRecordDoc` 两处校验，向后兼容纯邮箱地址
- `from` 原样透传给 nodemailer/postmark，二者本身支持带显示名格式，传输层无需改动

## Test plan
- [x] `pnpm lint` 通过
- [x] `pnpm test` 全部通过（51 passed）
- [ ] 调用 `@sendEmail` 传入 `"robot" <robot@mail.36node.com>`，确认收件方显示名正确
- [ ] 传入纯邮箱地址，确认行为与原来一致

Made with [Cursor](https://cursor.com)