### PR TITLE
fix: allow legacy weak old password when updating password

### DIFF
--- a/src/user/dto/update-password.dto.ts
+++ b/src/user/dto/update-password.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { IsPassword } from 'src/common/validate';
 
@@ -7,7 +7,7 @@ export class UpdatePasswordDto {
    * 旧密码
    */
   @IsOptional()
-  @IsPassword()
+  @IsString()
   oldPassword?: string;
 
   /**

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -179,6 +179,20 @@ describe('User crud (e2e)', () => {
       .set('Accept', 'application/json')
       .expect(200);
 
+    // 旧密码不符合当前强度策略时仍可改密（legacy 用户）
+    const legacyUserDoc = { ...mockUser(), password: 'abc123' };
+    const legacyUser = await userService.create(legacyUserDoc);
+    await request(app.getHttpServer())
+      .post(`/users/${legacyUser.id}/@updatePassword`)
+      .send({
+        oldPassword: 'abc123',
+        newPassword: '^tR123456',
+      })
+      .set('Content-Type', 'application/json')
+      .set('x-api-key', auth.apiKey)
+      .set('Accept', 'application/json')
+      .expect(204);
+
     // username 不合法
     await request(app.getHttpServer())
       .patch(`/users/${user.id}`)


### PR DESCRIPTION
## Summary
- 修改密码时不再对 `oldPassword` 做强度校验，改为仅 `@IsString()`，由 hash 比对验证旧密码
- `newPassword` 仍保持 `@IsPassword()` 强度要求不变
- 新增 e2e 用例：legacy 用户用弱旧密码（如 `abc123`）可成功改密

## Test plan
- [x] `npm run test` 单元测试通过
- [ ] `npm run test:e2e` 中 Update user 用例（需 MongoDB）


Made with [Cursor](https://cursor.com)