### PR TITLE
feat(sms): support optional account for volcengine multi-account

### DIFF
--- a/env.example
+++ b/env.example
@@ -55,7 +55,7 @@
 # ALIYUN_SECRET=
 
 # 火山引擎短信
-# VOLCENGINE_SMS_ACCOUNT=
+# VOLCENGINE_SMS_ACCOUNT=  # 默认消息组 ID；国际短信可由调用方在 sendSms 请求中传 account 覆盖
 # VOLCENGINE_KEY=
 # VOLCENGINE_SECRET=
 

--- a/openapi.json
+++ b/openapi.json
@@ -1,5 +1,5 @@
 {
-  "hash": "784097a775e52168883b76a7f9a709a61104d472edba7731896d3f0369068f3f",
+  "hash": "3ddac25e611b3cfd7e7ad88c1d3cceca02221dbcc795f005c5721f01be42b86a",
   "openapi": "3.0.0",
   "paths": {
     "/hello": {
@@ -7368,6 +7368,10 @@
           },
           "params": {
             "type": "object"
+          },
+          "account": {
+            "type": "string",
+            "description": "火山引擎消息组 ID；未传时使用 VOLCENGINE_SMS_ACCOUNT"
           }
         },
         "required": [
@@ -7411,6 +7415,10 @@
             "type": "string",
             "description": "参数"
           },
+          "account": {
+            "type": "string",
+            "description": "火山引擎消息组 ID"
+          },
           "sentAt": {
             "format": "date-time",
             "type": "string",
@@ -7450,6 +7458,10 @@
           "params": {
             "type": "string",
             "description": "参数"
+          },
+          "account": {
+            "type": "string",
+            "description": "火山引擎消息组 ID"
           },
           "sentAt": {
             "format": "date-time",

--- a/openapi.json
+++ b/openapi.json
@@ -1,5 +1,5 @@
 {
-  "hash": "3ddac25e611b3cfd7e7ad88c1d3cceca02221dbcc795f005c5721f01be42b86a",
+  "hash": "ef6200b85a5a096b716c3bc8e84e84d57e7c515a9a8c4e3e24ee300bd1079bdc",
   "openapi": "3.0.0",
   "paths": {
     "/hello": {
@@ -7525,6 +7525,10 @@
           "params": {
             "type": "string",
             "description": "参数"
+          },
+          "account": {
+            "type": "string",
+            "description": "火山引擎消息组 ID"
           },
           "sentAt": {
             "format": "date-time",

--- a/src/sms/dto/send-sms.dto.ts
+++ b/src/sms/dto/send-sms.dto.ts
@@ -15,4 +15,9 @@ export class SendSmsDto {
 
   @IsOptional()
   params?: Record<string, string>;
+
+  /** 火山引擎消息组 ID；未传时使用 VOLCENGINE_SMS_ACCOUNT */
+  @IsOptional()
+  @IsString()
+  account?: string;
 }

--- a/src/sms/entities/sms-record.entity.ts
+++ b/src/sms/entities/sms-record.entity.ts
@@ -55,6 +55,14 @@ export class SmsRecordDoc {
   params?: string;
 
   /**
+   * 火山引擎消息组 ID
+   */
+  @IsOptional()
+  @IsString()
+  @Prop()
+  account?: string;
+
+  /**
    * 发送时间
    */
   @IsOptional()

--- a/src/sms/sms.controller.ts
+++ b/src/sms/sms.controller.ts
@@ -33,7 +33,10 @@ export class SmsController {
   @Post('@sendSms')
   async sendSms(@Body() body: SendSmsDto) {
     const dto: CreateSmsRecordDto = {
-      ...body,
+      phone: body.phone,
+      sign: body.sign,
+      template: body.template,
+      account: this.smsService.resolveAccount(body),
       status: SmsStatus.PENDING,
       params: body.params ? JSON.stringify(body.params) : undefined,
     };

--- a/src/sms/sms.service.spec.ts
+++ b/src/sms/sms.service.spec.ts
@@ -61,4 +61,23 @@ describe('SmsService', () => {
       expect.objectContaining({ SmsAccount: config.sms.volcengine.account })
     );
   });
+
+  it('resolveAccount returns dto account or env default for volcengine', () => {
+    expect(
+      service.resolveAccount({
+        phone: '+8613800138000',
+        sign: 'sign',
+        template: 'tpl',
+        account: 'foreign-account',
+      })
+    ).toBe('foreign-account');
+
+    expect(
+      service.resolveAccount({
+        phone: '+8613800138000',
+        sign: 'sign',
+        template: 'tpl',
+      })
+    ).toBe(config.sms.volcengine.account);
+  });
 });

--- a/src/sms/sms.service.spec.ts
+++ b/src/sms/sms.service.spec.ts
@@ -1,0 +1,64 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import * as config from 'src/config';
+
+import { SmsService } from './sms.service';
+
+jest.mock('src/config', () => ({
+  sms: {
+    provider: 'volcengine',
+    aliyun: { keyId: '', keySecret: '' },
+    volcengine: {
+      account: 'default-account',
+      accessKeyId: 'key',
+      secretKey: 'secret',
+    },
+  },
+}));
+
+const sendMock = jest.fn().mockResolvedValue({ ResponseMetadata: {} });
+
+jest.mock('@volcengine/openapi/lib/services/sms', () => ({
+  SmsService: jest.fn().mockImplementation(() => ({
+    setAccessKeyId: jest.fn(),
+    setSecretKey: jest.fn(),
+    Send: sendMock,
+  })),
+}));
+
+describe('SmsService', () => {
+  let service: SmsService;
+
+  beforeEach(async () => {
+    sendMock.mockClear();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SmsService],
+    }).compile();
+    service = module.get(SmsService);
+  });
+
+  it('uses account from dto when provided', async () => {
+    await service.send({
+      phone: '+8613800138000',
+      sign: 'sign',
+      template: 'tpl',
+      account: 'foreign-account',
+    });
+
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ SmsAccount: 'foreign-account' })
+    );
+  });
+
+  it('falls back to env default account when dto.account is omitted', async () => {
+    await service.send({
+      phone: '+8613800138000',
+      sign: 'sign',
+      template: 'tpl',
+    });
+
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ SmsAccount: config.sms.volcengine.account })
+    );
+  });
+});

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -66,10 +66,14 @@ export class SmsService {
     return this.volcengineClient;
   }
 
+  private resolveVolcengineAccount(dto: SendSmsDto): string | undefined {
+    return dto.account ?? config.sms.volcengine.account;
+  }
+
   private async sendByVolcengine(dto: SendSmsDto) {
     const { phone, sign, template, params } = dto;
     const res = await this.getVolcengineClient().Send({
-      SmsAccount: config.sms.volcengine.account,
+      SmsAccount: this.resolveVolcengineAccount(dto),
       Sign: sign,
       TemplateID: template,
       PhoneNumbers: phone,

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -66,14 +66,18 @@ export class SmsService {
     return this.volcengineClient;
   }
 
-  private resolveVolcengineAccount(dto: SendSmsDto): string | undefined {
+  /** 实际用于发送的消息组 ID（volcengine 未传时回退 env 默认） */
+  resolveAccount(dto: SendSmsDto): string | undefined {
+    if (this.getProvider() !== 'volcengine') {
+      return dto.account;
+    }
     return dto.account ?? config.sms.volcengine.account;
   }
 
   private async sendByVolcengine(dto: SendSmsDto) {
     const { phone, sign, template, params } = dto;
     const res = await this.getVolcengineClient().Send({
-      SmsAccount: this.resolveVolcengineAccount(dto),
+      SmsAccount: this.resolveAccount(dto),
       Sign: sign,
       TemplateID: template,
       PhoneNumbers: phone,


### PR DESCRIPTION
## Summary
- Add optional `account` field to `SendSmsDto` for Volcengine SmsAccount (消息组 ID)
- `SmsService` uses `dto.account ?? VOLCENGINE_SMS_ACCOUNT` when sending via volcengine
- Persist `account` on `SmsRecord` for audit

## Test plan
- [x] Unit tests: `sms.service.spec.ts` (dto account vs env fallback)
- [ ] Deploy preview env and send domestic/foreign SMS with different accounts


Made with [Cursor](https://cursor.com)