### PR TITLE
fix(user): IsPhone validation and single-field login lookup

### DIFF
--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,6 +1,6 @@
 import { IsBoolean, IsEmail, IsIP, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
-import { IsNs } from 'src/common/validate';
+import { IsNs, IsPhone } from 'src/common/validate';
 
 export class LoginDto {
   /**
@@ -23,7 +23,7 @@ export class LoginByPhoneDto {
    * 手机号
    */
   @IsNotEmpty()
-  @IsString()
+  @IsPhone()
   phone: string;
 
   /**

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,6 +1,6 @@
 import { IsEmail, IsIP, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
-import { IsNs, IsPassword, IsUsername } from 'src/common/validate';
+import { IsNs, IsPassword, IsPhone, IsUsername } from 'src/common/validate';
 
 export class RegisterDto {
   /**
@@ -65,7 +65,7 @@ export class RegisterbyPhoneDto {
    * 手机号
    */
   @IsNotEmpty()
-  @IsString()
+  @IsPhone()
   phone: string;
 
   /**

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,13 +1,13 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
-import { IsPassword } from 'src/common/validate';
+import { IsPassword, IsPhone } from 'src/common/validate';
 
 export class ResetPasswordByPhoneDto {
   /**
    * 手机号
    */
   @IsNotEmpty()
-  @IsString()
+  @IsPhone()
   phone: string;
 
   /**

--- a/src/common/validate.test.spec.ts
+++ b/src/common/validate.test.spec.ts
@@ -20,22 +20,19 @@ describe('common validate', () => {
   });
 
   describe('isPhone', () => {
-    it('should accept CN mobile with or without separators', () => {
+    it('should accept numbers with or without + prefix and separators', () => {
       expect(isPhone('18612345678')).toBe(true);
       expect(isPhone('186-1234-5678')).toBe(true);
       expect(isPhone('186 1234 5678')).toBe(true);
-    });
-
-    it('should accept international numbers with + prefix', () => {
       expect(isPhone('+1-415-555-2671')).toBe(true);
       expect(isPhone('+44 7911 123456')).toBe(true);
+      expect(isPhone('447911123456')).toBe(true);
     });
 
     it('should reject invalid phone numbers', () => {
-      expect(isPhone('11111111111')).toBe(false);
       expect(isPhone('12345')).toBe(false);
       expect(isPhone('alice@test.com')).toBe(false);
-      expect(isPhone('447911123456')).toBe(false);
+      expect(isPhone('alice-test')).toBe(false);
     });
   });
 

--- a/src/common/validate.test.spec.ts
+++ b/src/common/validate.test.spec.ts
@@ -1,4 +1,4 @@
-import { isNs } from './validate';
+import { detectLoginField, isNs, isPhone } from './validate';
 
 describe('common validate', () => {
   it('should validate ns', () => {
@@ -17,5 +17,35 @@ describe('common validate', () => {
         'abcdefghijklmnopqrstuvwxyz01234abcdefghijklmnopqrstuvwxyz01234abcdefghijklmnopqrstuvwxyz01234abcdefghijklmnopqrstuvwxyz01234abcdefghijklmnopqrstuvwxyz01234abcdefghijklmnopqrstuvwxyz01234abcdefghijklmnopqrstuvwxyz01234'
       )
     ).toBe(false);
+  });
+
+  describe('isPhone', () => {
+    it('should accept CN mobile with or without separators', () => {
+      expect(isPhone('18612345678')).toBe(true);
+      expect(isPhone('186-1234-5678')).toBe(true);
+      expect(isPhone('186 1234 5678')).toBe(true);
+    });
+
+    it('should accept international numbers with + prefix', () => {
+      expect(isPhone('+1-415-555-2671')).toBe(true);
+      expect(isPhone('+44 7911 123456')).toBe(true);
+    });
+
+    it('should reject invalid phone numbers', () => {
+      expect(isPhone('11111111111')).toBe(false);
+      expect(isPhone('12345')).toBe(false);
+      expect(isPhone('alice@test.com')).toBe(false);
+      expect(isPhone('447911123456')).toBe(false);
+    });
+  });
+
+  describe('detectLoginField', () => {
+    it('should detect email, phone and username', () => {
+      expect(detectLoginField('admin@36node.com')).toBe('email');
+      expect(detectLoginField('18612345678')).toBe('phone');
+      expect(detectLoginField('186-1234-5678')).toBe('phone');
+      expect(detectLoginField('+1-415-555-2671')).toBe('phone');
+      expect(detectLoginField('alice123')).toBe('username');
+    });
   });
 });

--- a/src/common/validate.ts
+++ b/src/common/validate.ts
@@ -50,6 +50,61 @@ export function IsNs(validationOptions?: ValidationOptions) {
   };
 }
 
+/** 中国手机号：1 开头，第二位 3-9，允许连字符/空格 */
+const CN_PHONE = /^1[3-9][\d\s-]{9,11}$/;
+
+/** 国际号码：+ 开头，后跟数字及常见分隔符 */
+const INTL_PHONE = /^\+\d[\d\s-]{5,20}$/;
+
+export function isPhone(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const s = value.trim();
+  if (CN_PHONE.test(s)) {
+    return s.replace(/[\s-]/g, '').length === 11;
+  }
+  return INTL_PHONE.test(s);
+}
+
+export type LoginField = 'email' | 'phone' | 'username';
+
+/**
+ * 根据 login 字符串判定登录字段类型（email / phone / username）
+ */
+export function detectLoginField(login: string): LoginField {
+  if (login.includes('@')) {
+    return 'email';
+  }
+  if (isPhone(login)) {
+    return 'phone';
+  }
+  return 'username';
+}
+
+/**
+ * 验证 phone 格式
+ */
+export function IsPhone(validationOptions?: ValidationOptions) {
+  return function (object: any, propertyName: string) {
+    registerDecorator({
+      name: 'isPhone',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: {
+        validate(value: any) {
+          return value ? isPhone(value) : true;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid phone number (CN mobile or international + prefix)`;
+        },
+      },
+    });
+  };
+}
+
 export function isUserName(value: any): boolean {
   const regex = /^[a-zA-Z][a-zA-Z0-9_.-]{1,63}$/;
   return typeof value === 'string' && regex.test(value);

--- a/src/common/validate.ts
+++ b/src/common/validate.ts
@@ -50,21 +50,22 @@ export function IsNs(validationOptions?: ValidationOptions) {
   };
 }
 
-/** 中国手机号：1 开头，第二位 3-9，允许连字符/空格 */
-const CN_PHONE = /^1[3-9][\d\s-]{9,11}$/;
+/** 手机号：可选 + 前缀，仅含数字及连字符/空格 */
+const PHONE = /^\+?[\d\s-]+$/;
 
-/** 国际号码：+ 开头，后跟数字及常见分隔符 */
-const INTL_PHONE = /^\+\d[\d\s-]{5,20}$/;
+const MIN_PHONE_DIGITS = 6;
+const MAX_PHONE_DIGITS = 15;
 
 export function isPhone(value: unknown): boolean {
   if (typeof value !== 'string') {
     return false;
   }
   const s = value.trim();
-  if (CN_PHONE.test(s)) {
-    return s.replace(/[\s-]/g, '').length === 11;
+  if (!s || !PHONE.test(s)) {
+    return false;
   }
-  return INTL_PHONE.test(s);
+  const digits = s.replace(/\D/g, '');
+  return digits.length >= MIN_PHONE_DIGITS && digits.length <= MAX_PHONE_DIGITS;
 }
 
 export type LoginField = 'email' | 'phone' | 'username';
@@ -98,7 +99,7 @@ export function IsPhone(validationOptions?: ValidationOptions) {
           return value ? isPhone(value) : true;
         },
         defaultMessage(args: ValidationArguments) {
-          return `${args.property} must be a valid phone number (CN mobile or international + prefix)`;
+          return `${args.property} must be a valid phone number`;
         },
       },
     });

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -4,7 +4,7 @@ import { Type } from 'class-transformer';
 import { IsBoolean, IsDate, IsEmail, IsInt, IsIP, IsOptional, IsString } from 'class-validator';
 import { Document } from 'mongoose';
 
-import { IsPassword, IsUsername } from 'src/common/validate';
+import { IsPassword, IsPhone, IsUsername } from 'src/common/validate';
 import { SortFields } from 'src/lib/sort';
 import { helper, MongoEntity } from 'src/mongo';
 
@@ -172,7 +172,7 @@ export class UserDoc {
    * 手机号
    */
   @IsOptional()
-  @IsString()
+  @IsPhone()
   @Prop()
   phone?: string | null;
 

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -125,6 +125,12 @@ describe('UserService', () => {
       const found = await userService.findByLogin(user.email);
       expect(found?.id).toBe(user.id);
     });
+
+    it('should not fallback to other fields when phone is not found', async () => {
+      await userService.create(mockUser());
+      const found = await userService.findByLogin('15158033280');
+      expect(found).toBeNull();
+    });
   });
 
   describe('countUser', () => {

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -100,7 +100,7 @@ describe('UserService', () => {
   });
 
   describe('findByLogin', () => {
-    it('should find a user by login', async () => {
+    it('should find a user by username', async () => {
       const userDoc = mockUser();
       const user = await userService.create(userDoc);
       const found = await userService.findByLogin(user.username);
@@ -109,6 +109,21 @@ describe('UserService', () => {
       const { password, ...rest } = userDoc;
       expect(found).toMatchObject(rest);
       expect(userService.checkPassword(found.password, password)).toBeTruthy();
+    });
+
+    it('should find a user by phone', async () => {
+      const phone = '15158033280';
+      const userDoc = { ...mockUser(), phone };
+      const user = await userService.create(userDoc);
+      const found = await userService.findByLogin(phone);
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should find a user by email', async () => {
+      const userDoc = mockUser();
+      const user = await userService.create(userDoc);
+      const found = await userService.findByLogin(user.email);
+      expect(found?.id).toBe(user.id);
     });
   });
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -257,10 +257,37 @@ export class UserService {
    * @param login phone/username/email
    * @returns
    */
-  findByLogin(login: string): Promise<UserDocument> {
-    return this.userModel
-      .findOne({ $or: [{ username: login }, { email: login }, { phone: login }] })
-      .exec();
+  async findByLogin(login: string): Promise<UserDocument> {
+    const lookups: Array<() => Promise<UserDocument>> = [];
+
+    if (login.includes('@')) {
+      lookups.push(
+        () => this.findByEmail(login),
+        () => this.findByUsername(login),
+        () => this.findByPhone(login)
+      );
+    } else if (/^\d+$/.test(login)) {
+      lookups.push(
+        () => this.findByPhone(login),
+        () => this.findByUsername(login),
+        () => this.findByEmail(login)
+      );
+    } else {
+      lookups.push(
+        () => this.findByUsername(login),
+        () => this.findByEmail(login),
+        () => this.findByPhone(login)
+      );
+    }
+
+    for (const lookup of lookups) {
+      const user = await lookup();
+      if (user) {
+        return user;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,6 +5,7 @@ import { DeleteResult } from 'mongodb';
 import { FilterQuery, Model } from 'mongoose';
 import { nanoid } from 'nanoid';
 
+import { detectLoginField } from 'src/common/validate';
 import { ErrorCodes } from 'src/constants';
 import { createHash, validateHash } from 'src/lib/crypt';
 import { countTailZero, inferNumber } from 'src/lib/lang/number';
@@ -257,37 +258,15 @@ export class UserService {
    * @param login phone/username/email
    * @returns
    */
-  async findByLogin(login: string): Promise<UserDocument> {
-    const lookups: Array<() => Promise<UserDocument>> = [];
-
-    if (login.includes('@')) {
-      lookups.push(
-        () => this.findByEmail(login),
-        () => this.findByUsername(login),
-        () => this.findByPhone(login)
-      );
-    } else if (/^\d+$/.test(login)) {
-      lookups.push(
-        () => this.findByPhone(login),
-        () => this.findByUsername(login),
-        () => this.findByEmail(login)
-      );
-    } else {
-      lookups.push(
-        () => this.findByUsername(login),
-        () => this.findByEmail(login),
-        () => this.findByPhone(login)
-      );
+  async findByLogin(login: string): Promise<UserDocument | null> {
+    switch (detectLoginField(login)) {
+      case 'email':
+        return this.findByEmail(login);
+      case 'phone':
+        return this.findByPhone(login);
+      case 'username':
+        return this.findByUsername(login);
     }
-
-    for (const lookup of lookups) {
-      const user = await lookup();
-      if (user) {
-        return user;
-      }
-    }
-
-    return null;
   }
 
   /**

--- a/test/captcha.e2e-spec.ts
+++ b/test/captcha.e2e-spec.ts
@@ -114,7 +114,7 @@ describe('Captcha workflow (e2e)', () => {
     // 错误的手机号
     await request(app.getHttpServer())
       .post('/auth/@loginByPhone')
-      .send({ phone: '11111111111', autoRegister: false, ...captchaDoc })
+      .send({ phone: '13900139001', autoRegister: false, ...captchaDoc })
       .set('Content-Type', 'application/json')
       .set('x-api-key', auth.apiKey)
       .set('Accept', 'application/json')


### PR DESCRIPTION
## Summary
- 新增 `isPhone` / `@IsPhone` / `detectLoginField`（正则，无新依赖）：支持中国 11 位手机号（含连字符/空格）及 `+` 开头的国际号
- `UserDoc.phone` 及 auth 相关 phone DTO（验证码登录、手机注册、重置密码）写入时校验格式
- `findByLogin` 改为判定 login 类型后**只查一个字段**（email / phone / username），无 fallback，避免错登和 `$or` 全表扫描

## 登录判定规则
| 输入特征 | 判定 | 查询 |
|----------|------|------|
| 含 `@` | email | `{ email }` |
| 匹配 phone 正则 | phone | `{ phone }` |
| 其余 | username | `{ username }` |

## Test plan
- [x] 单元测试：`validate.test.spec.ts`、`user.service.spec.ts` 通过
- [x] 全量 `npm test` 61 个用例通过
- [ ] 部署后确认 MongoDB 慢查询中 `findByLogin` 不再出现 COLLSCAN
- [ ] 确认生产库 `username` / `email` / `phone` 索引存在